### PR TITLE
Add error message when no URLs given

### DIFF
--- a/downloaders/downloaders/base_downloader.py
+++ b/downloaders/downloaders/base_downloader.py
@@ -289,6 +289,8 @@ class BaseDownloader:
             urls = [urls]
         if is_iterable(urls):
             urls = list(urls)
+        if not urls:
+            raise ValueError("No URLs given to download")
         if paths is not None and isinstance(paths, str):
             paths = [paths]
         if is_iterable(paths):


### PR DESCRIPTION
I'm using `pubmed_embedding` right now and when I queried for recent papers (which probably aren't there because it hasn't been updated in the last month), it creates an empty list of URLs, which ultimately lead to a cryptic error message from the `Pool()` object due to `min(len(urls), self._processes)` being zero.

This PR adds a more specific error message